### PR TITLE
feat: add option to set ContentEncoding metadata to gzip on file-by-file basis

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ var defaultConfig = {
   exclude: [],
   corsConfiguration: [],
   enableCloudfront: false,
-  retries: 20
+  retries: 20,
+  gzippedFiles: []
 }
 
 var templateConfig = Object.assign({},
@@ -187,7 +188,8 @@ function uploadFile (s3, config, file, cb) {
     Key: normalizeKey(config.prefix, file),
     Body: fs.createReadStream(path.join(config.uploadDir, file)),
     ContentType: contentType || mime.lookup(file),
-    CacheControl: (config.cacheControl != null) ? config.cacheControl : null
+    CacheControl: (config.cacheControl != null) ? config.cacheControl : null,
+    ContentEncoding: config.gzippedFiles.includes(file) ? "gzip" : null
   }
 
   logUpdate('Uploading: ' + file)


### PR DESCRIPTION
This PR allows us to pass in an array of filepaths which should be uploaded to S3 with the ContentEncoding metadata set to the value `gzip`. This allows us to fix a major deployment bug described in jalMogo/mgmt#266.

See e.g. https://github.com/mapseed/platform/pull/1281 for an example of how this is used.